### PR TITLE
Return boolean signalling success from format functions

### DIFF
--- a/lua/lsp-format-modifications/init.lua
+++ b/lua/lsp-format-modifications/init.lua
@@ -56,6 +56,15 @@ end
 
 
 M.format_modifications = function(lsp_client, bufnr, config)
+  local err = prechecks(lsp_client, bufnr, config)
+  if err ~= nil then
+    util.notify(
+      "failed checks: " .. err,
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
   local bufname = vim.fn.bufname(bufnr)
 
   local vcs_client = vcs[config.vcs]:new()

--- a/lua/lsp-format-modifications/init.lua
+++ b/lua/lsp-format-modifications/init.lua
@@ -205,7 +205,9 @@ M.attach = function(lsp_client, bufnr, provided_config)
       {
         group = augroup_id,
         buffer = bufnr,
-        callback = M.format_modifications_current_buffer,
+        callback = function()
+          M.format_modifications_buffer(bufnr)
+        end,
       }
     )
   end

--- a/lua/lsp-format-modifications/init.lua
+++ b/lua/lsp-format-modifications/init.lua
@@ -180,8 +180,13 @@ M.format_modifications_buffer = function(bufnr)
 
   for client_id, config in pairs(ctx) do
     local lsp_client = vim.lsp.get_client_by_id(tonumber(client_id))
-    M.format_modifications(lsp_client, bufnr, config)
+    local success = M.format_modifications(lsp_client, bufnr, config)
+    if not success then
+      return false
+    end
   end
+
+  return true
 end
 
 M.format_modifications_current_buffer = function()

--- a/lua/lsp-format-modifications/init.lua
+++ b/lua/lsp-format-modifications/init.lua
@@ -62,7 +62,7 @@ M.format_modifications = function(lsp_client, bufnr, config)
       "failed checks: " .. err,
       vim.log.levels.ERROR
     )
-    return
+    return false
   end
 
   local bufname = vim.fn.bufname(bufnr)
@@ -75,7 +75,7 @@ M.format_modifications = function(lsp_client, bufnr, config)
       err .. ", doing nothing",
       vim.log.levels.WARN
     )
-    return
+    return false
   end
 
   local file_info = vcs_client:file_info(bufname)
@@ -86,13 +86,13 @@ M.format_modifications = function(lsp_client, bufnr, config)
       id = lsp_client.id,
       bufnr = bufnr
     }
-    return
+    return true
   end
 
   if file_info.has_conflicts then
     -- the file is marked as conflicted, so it probably has conflict markers.
     -- don't do anything to avoid screwing things up.
-    return
+    return true
     -- TODO: we should probably calculate the diff between the file on-disk and
     -- the common ancestor here
   end
@@ -103,7 +103,7 @@ M.format_modifications = function(lsp_client, bufnr, config)
       "failed to get comparee, " .. err .. " -- consider raising a GitHub issue",
       vim.log.levels.ERROR
     )
-    return
+    return false
   end
 
   local comparee_content = table.concat(comparee_lines, "\n")
@@ -175,7 +175,7 @@ M.format_modifications_buffer = function(bufnr)
       "no supported LSP clients attached to buffer, nothing to do",
       vim.log.levels.WARN
     )
-    return
+    return false
   end
 
   for client_id, config in pairs(ctx) do
@@ -200,7 +200,7 @@ M.attach = function(lsp_client, bufnr, provided_config)
       "failed checks: " .. err,
       vim.log.levels.ERROR
     )
-    return
+    return false
   end
 
   if config.format_on_save then
@@ -233,6 +233,8 @@ M.attach = function(lsp_client, bufnr, provided_config)
     M.format_modifications_current_buffer,
     {}
   )
+
+  return true
 end
 
 return M

--- a/lua/lsp-format-modifications/init.lua
+++ b/lua/lsp-format-modifications/init.lua
@@ -140,9 +140,7 @@ M.format_modifications = function(lsp_client, bufnr, config)
   end
 end
 
-M.format_modifications_current_buffer = function()
-  local bufnr = vim.fn.bufnr("%") -- work on the current buffer
-
+M.format_modifications_buffer = function(bufnr)
   local ctx = vim.b[bufnr].lsp_format_modifications_context
   if ctx == nil then
     -- ... attaching to the buffer has either not been performed via attach, or
@@ -158,6 +156,11 @@ M.format_modifications_current_buffer = function()
     local lsp_client = vim.lsp.get_client_by_id(tonumber(client_id))
     M.format_modifications(lsp_client, bufnr, config)
   end
+end
+
+M.format_modifications_current_buffer = function()
+  local bufnr = vim.fn.bufnr("%") -- work on the current buffer
+  return M.format_modifications_buffer(bufnr)
 end
 
 local function attach_prechecks(lsp_client, bufnr, config)

--- a/lua/lsp-format-modifications/init.lua
+++ b/lua/lsp-format-modifications/init.lua
@@ -216,7 +216,7 @@ M.attach = function(lsp_client, bufnr, provided_config)
         group = augroup_id,
         buffer = bufnr,
         callback = function()
-          M.format_modifications_buffer(bufnr)
+          M.format_modifications(lsp_client, bufnr, config)
         end,
       }
     )


### PR DESCRIPTION
Return true if formatting modifications was successful, false otherwise. This can be used to fall back to full document formatting if the file in question is not in a Git repository. See #4.