### PR TITLE
Support jdtls (with workaround for incomplete server_capabilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,13 @@ an example) — pull requests are very welcome.
 
 ## Tested language servers
 
-| Language server      | Works with `lsp-format-modifications.nvim`? | More info                                                                                                                                                                                       |
-| -------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `clangd`             | ✅                                          |                                                                                                                                                                                                 |
-| `tsserver`           | ✅                                          |                                                                                                                                                                                                 |
-| `null_ls`            | ✅                                          | See [this issue](https://github.com/joechrisellis/lsp-format-modifications.nvim/issues/1#issuecomment-1275302811) for how to get set up — only sources that support range formatting will work. |
-| `lua-language-server`| ✅                                          | For best results, set the `experimental_empty_line_handling` option in config.                                                                                                                  |
+| Language server       | Works with `lsp-format-modifications.nvim`? | More info                                                                                                                                                                                       |
+| --------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `clangd`              | ✅                                          |                                                                                                                                                                                                 |
+| `tsserver`            | ✅                                          |                                                                                                                                                                                                 |
+| `null_ls`             | ✅                                          | See [this issue](https://github.com/joechrisellis/lsp-format-modifications.nvim/issues/1#issuecomment-1275302811) for how to get set up — only sources that support range formatting will work. |
+| `lua-language-server` | ✅                                          | For best results, set the `experimental_empty_line_handling` option in config.                                                                                                                  |
+| `jdtls`               | ✅                                          | The client does not reliably find the `documentRangeFormattingProvider` element in server_capabilities, but it's tested to work to regardless                                                   |
 
 [git-vcs]: https://git-scm.com
 [mercurial-vcs]: https://www.mercurial-scm.org

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ A complete configuration table is below:
 local config = {
   -- The callback that is invoked to compute a diff so that we know what to
   -- format. This defaults to vim.diff with some sensible defaults.
-  diff_callback = function(compareee_content, buf_content)
-    return vim.diff(compareee_content, buf_content, {...})
+  diff_callback = function(comparee_content, buf_content)
+    return vim.text.diff(comparee_content, buf_content, { result_type = "indices" })
   end,
 
   -- The callback that is invoked to actually do the formatting on the changed

--- a/lua/lsp-format-modifications/init.lua
+++ b/lua/lsp-format-modifications/init.lua
@@ -39,9 +39,10 @@ local base_config = {
 }
 
 local function prechecks(lsp_client, bufnr, config)
-  -- if not lsp_client.server_capabilities.documentRangeFormattingProvider or lsp_client.name == "jdtls" then -- unsupported server
-  --   return "client " .. lsp_client.name .. " does not have a document range formatting provider"
-  -- end
+  if not lsp_client.server_capabilities.documentRangeFormattingProvider -- unsupported server
+      and lsp_client.name ~= "jdtls" then -- jdtls works, but does not reliably report the capability
+    return "client " .. lsp_client.name .. " does not have a document range formatting provider"
+  end
 
   if vcs[config.vcs] == nil then -- unsupported VCS
     return "VCS " .. config.vcs .. " isn't supported"

--- a/lua/lsp-format-modifications/init.lua
+++ b/lua/lsp-format-modifications/init.lua
@@ -39,7 +39,7 @@ local base_config = {
 }
 
 local function prechecks(lsp_client, bufnr, config)
-  if not lsp_client.server_capabilities.documentRangeFormattingProvider then -- unsupported server
+  if not lsp_client.server_capabilities.documentRangeFormattingProvider or lsp_client.name == "jdtls" then -- unsupported server
     return "client " .. lsp_client.name .. " does not have a document range formatting provider"
   end
 

--- a/lua/lsp-format-modifications/init.lua
+++ b/lua/lsp-format-modifications/init.lua
@@ -39,9 +39,9 @@ local base_config = {
 }
 
 local function prechecks(lsp_client, bufnr, config)
-  if not lsp_client.server_capabilities.documentRangeFormattingProvider or lsp_client.name == "jdtls" then -- unsupported server
-    return "client " .. lsp_client.name .. " does not have a document range formatting provider"
-  end
+  -- if not lsp_client.server_capabilities.documentRangeFormattingProvider or lsp_client.name == "jdtls" then -- unsupported server
+  --   return "client " .. lsp_client.name .. " does not have a document range formatting provider"
+  -- end
 
   if vcs[config.vcs] == nil then -- unsupported VCS
     return "VCS " .. config.vcs .. " isn't supported"


### PR DESCRIPTION
Hi, I've tested lsp-format-modifications.nvim  using `jdtls` (using the [mfussenegger/nvim-jdtls plugin](https://github.com/mfussenegger/nvim-jdtls), and it worked correctly (did no format the whole file, just the changes reported by git). The only caveat was that I had to remove/bypass the `prechecks` because the server_capabilities where not containing the necessary capability for this plugin. As I've known there are some quirks with `jdtls`, and even though I've seen [reports online where the capability is actually there](https://github.com/mfussenegger/nvim-jdtls/discussions/329#discussion-4412143), I 've made it work by allowing jdtls to not have the capability in `prechecks` conditions in my personal fork.

lsp-format-modifications.nvim solves a relevant problem of mine and of work colleagues, so I'm thankful for work contribution with this plugin, cheers!